### PR TITLE
Allow hooking the queueable collection logic

### DIFF
--- a/src/Illuminate/Database/Eloquent/Collection.php
+++ b/src/Illuminate/Database/Eloquent/Collection.php
@@ -665,16 +665,32 @@ class Collection extends BaseCollection implements QueueableCollection
             return;
         }
 
-        $class = get_class($this->first());
+        $class = $this->getModelClass($this->first());
 
         $this->each(function ($model) use ($class) {
-            if (get_class($model) !== $class) {
+            if ($this->getModelClass($model) !== $class) {
                 throw new LogicException('Queueing collections with multiple model types is not supported.');
             }
         });
 
         return $class;
     }
+
+    /**
+     * Get the identifiers for all of the entities.
+     *
+     * @return array<int, mixed>
+     */
+    protected function getModelClass($model)
+    {
+        if(method_exists($model,'getClassNameForSerialization')) {
+                return $model->getClassNameForSerialization();
+        }
+        
+        return get_class($model);
+    }
+    
+    
 
     /**
      * Get the identifiers for all of the entities.


### PR DESCRIPTION
This allows the use of parent/child Models in the same collection, to be properly serialized using the parent model (given a proper trait that facilitates the new function). Parent/child models as implemented in for example (https://github.com/calebporzio/parental) currently cause serialization errors when attempting to queue or otherwise serialize a collection containing them. 

This hook would allow us to alleviate the issue.

<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
